### PR TITLE
Rename title to TUI 웹 에디터

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function App() {
   return (
     <div className="min-h-screen bg-gray-100 flex items-center justify-center p-10">
       <div className="bg-white shadow-xl rounded-2xl p-6 w-full max-w-4xl">
-        <h1 className="text-2xl font-bold mb-4">TUI Web Editor + React</h1>
+        <h1 className="text-2xl font-bold mb-4">TUI 웹 에디터</h1>
 
         {/* 실제 Editor는 여기 div에 붙음 */}
         <div ref={editorRef} />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,12 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: [
     "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",   // ← React/Vite 경로 지정
+    "./src/**/*.{js,ts,jsx,tsx}", // ← React/Vite 경로 지정
   ],
   theme: {
     extend: {},
   },
   plugins: [],
-}
+};
+


### PR DESCRIPTION
## Summary
- Replace heading text with "TUI 웹 에디터"
- Convert Tailwind config to ES module to satisfy linting

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7a52f2f7c83278da79e6dc0eeb8f2